### PR TITLE
chore: add amplify.yml to specify Node.js version for AWS Amplify builds

### DIFF
--- a/frontend/amplify.yml
+++ b/frontend/amplify.yml
@@ -1,0 +1,18 @@
+version: 1
+frontend:
+  phases:
+    preBuild:
+      commands:
+        - nvm install 20
+        - nvm use 20
+        - yarn install
+    build:
+      commands:
+        - yarn build
+  artifacts:
+    baseDirectory: build
+    files:
+      - '**/*'
+  cache:
+    paths:
+      - node_modules/**/*

--- a/frontend/src/routes/protected-route.tsx
+++ b/frontend/src/routes/protected-route.tsx
@@ -21,7 +21,6 @@ export function ProtectedRoute({ children }: { children: React.JSX.Element }) {
           setIsAuthenticated(true);
         } else {
           setIsAuthenticated(false);
-          L;
         }
       } catch (error) {
         console.error("Error checking authentication:", error);

--- a/frontend/trust-policy.json
+++ b/frontend/trust-policy.json
@@ -1,0 +1,10 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "amplify.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }]
+  }


### PR DESCRIPTION
This PR adds an `amplify.yml` file to explicitly set the Node.js version to v20 for AWS Amplify deployments.

### Changes:
- Adds `amplify.yml` at the root of the frontend directory.
- Configures Node.js v20 to fix build compatibility issues.

### Reason:
AWS Amplify's default Node.js (v18) was incompatible with dependencies like `react-router-dom@7.2.0`, causing build failures.

### Testing:
Verified that Amplify correctly picks up Node v20 and completes the frontend build successfully.